### PR TITLE
Add badge and integration for Dependency CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/craigthomas/Chip8Python.svg?branch=master)](https://travis-ci.org/craigthomas/Chip8Python) 
 [![Coverage Status](https://coveralls.io/repos/github/craigthomas/Chip8Python/badge.svg?branch=master)](https://coveralls.io/github/craigthomas/Chip8Python?branch=master) 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/f100b6deb9bf4729a2c55ef12fb695c9)](https://www.codacy.com/app/craig-thomas/Chip8Python?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=craigthomas/Chip8Python&amp;utm_campaign=Badge_Grade)
+[![Dependency Status](https://dependencyci.com/github/craigthomas/Chip8Python/badge)](https://dependencyci.com/github/craigthomas/Chip8Python)
 
 ## What is it?
 


### PR DESCRIPTION
This PR updates the README to include a badge for Dependency CI (replaces VersionEye).