### PR TITLE
Update SHL and SHR to use target register.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
     2. [Screen Scale](#screen-scale)
     3. [Execution Delay](#execution-delay)
 5. [Customization](#customization)
+    1. [Keys](#keys)
+    2. [Debug Keys](#debug-keys)
 6. [Further Documentation](#further-documentation)
 
 ## What is it?
@@ -45,7 +47,7 @@ Copy the source files to a directory of your choice. In addition to
 the source, you will need the following required software packages:
 
 * [Python 2.7](http://www.python.org)
-* [pygame](http://http://www.pygame.org)
+* [pygame](http://www.pygame.org)
 
 I strongly recommend creating a virtual environment using the 
 [virtualenv](http://pypi.python.org/pypi/virtualenv) builder as well as the
@@ -199,18 +201,46 @@ set amount of time).
 ## Customization
 
 The file `chip8/config.py` contains several variables that can be changed to
-customize the operation of the emulator. The most important one is the 
-`KEY_MAPPINGS` variable. The Chip 8 has 16 keys:
+customize the operation of the emulator.  The Chip 8 has 16 keys:
 
-* The keys 0-9
-* The letters A-F
+### Keys
 
-The default configuration of the emulator will map the keypad numeric keys
-0-9 to the keys 0-9, and the keyboard keys a-f onto A-F. If you wish to 
-configure a different key-mapping, simply change the variable to reflect
-the mapping that you want. The [pygame.key](http://pygame.readthedocs.org/en/latest/ref/key.html)
-documentation contains a list of all the valid constants for keyboard
-key values.
+The original Chip 8 had a keypad with the numbered keys 0 - 9 and A - F (16
+keys in total). Without any modifications to the emulator, the keys are mapped
+as follows:
+
+| Chip 8 Key | Keyboard Key |
+| :--------: | :----------: |
+| `1`        | `4`          |
+| `2`        | `5`          |
+| `3`        | `6`          |
+| `4`        | `7`          |
+| `5`        | `R`          |
+| `6`        | `T`          |
+| `7`        | `Y`          |
+| `8`        | `U`          |
+| `9`        | `F`          |
+| `0`        | `G`          |
+| `A`        | `H`          |
+| `B`        | `J`          |
+| `C`        | `V`          |
+| `D`        | `B`          |
+| `E`        | `N`          |
+| `F`        | `M`          |
+
+If you wish to configure a different key-mapping, simply change the `KEY_MAPPINGS` variable
+in the configuration file to reflect the mapping that you want. The
+[pygame.key](https://www.pygame.org/docs/ref/key.html) documentation contains a
+list of all the valid constants for keyboard key values.
+
+### Debug Keys
+
+In addition to the key mappings specified in the configuration file, there are additional
+keys that impact the execution of the emulator.
+
+| Keyboard Key | Effect |
+| :----------: | ------ |
+| `ESC`        | Quits the emulator             |
 
 
 ## Further Documentation

--- a/chip8/config.py
+++ b/chip8/config.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2012 Craig Thomas
+Copyright (C) 2012-2019 Craig Thomas
 This project uses an MIT style license - see LICENSE for details.
 
 A simple Chip 8 emulator - see the README file for more information.
@@ -21,22 +21,22 @@ PROGRAM_COUNTER_START = 0x200
 
 # Sets which keys on the keyboard map to the Chip 8 keys
 KEY_MAPPINGS = {
-    0x0: pygame.K_KP0,
-    0x1: pygame.K_KP1,
-    0x2: pygame.K_KP2,
-    0x3: pygame.K_KP3,
-    0x4: pygame.K_KP4,
-    0x5: pygame.K_KP5,
-    0x6: pygame.K_KP6,
-    0x7: pygame.K_KP7,
-    0x8: pygame.K_KP8,
-    0x9: pygame.K_KP9,
-    0xA: pygame.K_a,
-    0xB: pygame.K_b,
-    0xC: pygame.K_c,
-    0xD: pygame.K_d,
-    0xE: pygame.K_e,
-    0xF: pygame.K_f,
+    0x0: pygame.K_g,
+    0x1: pygame.K_4,
+    0x2: pygame.K_5,
+    0x3: pygame.K_6,
+    0x4: pygame.K_7,
+    0x5: pygame.K_r,
+    0x6: pygame.K_t,
+    0x7: pygame.K_y,
+    0x8: pygame.K_u,
+    0x9: pygame.K_f,
+    0xA: pygame.K_h,
+    0xB: pygame.K_j,
+    0xC: pygame.K_v,
+    0xD: pygame.K_b,
+    0xE: pygame.K_n,
+    0xF: pygame.K_m,
 }
 
 # The font file to use

--- a/chip8/cpu.py
+++ b/chip8/cpu.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2012 Craig Thomas
+Copyright (C) 2012-2019 Craig Thomas
 This project uses an MIT style license - see LICENSE for details.
 
 A Chip 8 CPU - see the README file for more information.
@@ -495,18 +495,20 @@ class Chip8CPU(object):
 
     def right_shift_reg(self):
         """
-        8s06 - SHR  Vs
+        8st6 - SHR  Vs, Vt
 
-        Shift the bits in the specified register 1 bit to the right. Bit
-        0 will be shifted into register vf. The register calculation is
-        as follows:
+        Shift the bits in the source register 1 bit to the right and
+        stores the result in the target register, leaving source
+        with its original value. Bit 0 will be shifted into register
+        vf. The register calculation is as follows:
 
            Bits:  15-12     11-8      7-4       3-0
-                  unused   source      0         6
+                  unused   source    target      6
         """
         source = (self.operand & 0x0F00) >> 8
+        target = (self.operand & 0x00F0) >> 4
         bit_zero = self.registers['v'][source] & 0x1
-        self.registers['v'][source] = self.registers['v'][source] >> 1
+        self.registers['v'][target] = self.registers['v'][source] >> 1
         self.registers['v'][0xF] = bit_zero
 
     def subtract_reg_from_reg1(self):
@@ -536,18 +538,20 @@ class Chip8CPU(object):
 
     def left_shift_reg(self):
         """
-        8s0E - SHL  Vs
+        8stE - SHL  Vs, Vt
 
-        Shift the bits in the specified register 1 bit to the left. Bit
-        7 will be shifted into register vf. The register calculation is
-        as follows:
+        Shift the bits in the source register 1 bit to the left and
+        stores the result in the target register, leaving the source
+        register with its original value. Bit 7 will be shifted into
+        register vf. The register calculation is as follows:
 
            Bits:  15-12     11-8      7-4       3-0
-                  unused   source      0         E
+                  unused   source    target      E
         """
         source = (self.operand & 0x0F00) >> 8
+        target = (self.operand & 0x00F0) >> 4
         bit_seven = (self.registers['v'][source] & 0x80) >> 8
-        self.registers['v'][source] = self.registers['v'][source] << 1
+        self.registers['v'][target] = self.registers['v'][source] << 1
         self.registers['v'][0xF] = bit_seven
 
     def skip_if_reg_not_equal_reg(self):

--- a/chip8/yac8e.py
+++ b/chip8/yac8e.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2012 Craig Thomas
+Copyright (C) 2012-2019 Craig Thomas
 This project uses an MIT style license - see LICENSE for details.
 
 A simple Chip 8 emulator - see the README file for more information.
@@ -68,7 +68,7 @@ def main_loop(args):
                 cpu.running = False
             if event.type == pygame.KEYDOWN:
                 keys_pressed = pygame.key.get_pressed()
-                if keys_pressed[pygame.K_q]:
+                if keys_pressed[pygame.K_ESCAPE]:
                     cpu.running = False
 
 

--- a/test/test_chip8cpu.py
+++ b/test/test_chip8cpu.py
@@ -13,7 +13,7 @@ import unittest
 from mock import patch, call
 
 from chip8.cpu import Chip8CPU, UnknownOpCodeException, MODE_EXTENDED
-from chip8.screen import Chip8Screen, DEFAULT_HEIGHT, DEFAULT_WIDTH
+from chip8.screen import Chip8Screen
 
 # C O N S T A N T S ###########################################################
 
@@ -281,6 +281,7 @@ class TestChip8CPU(unittest.TestCase):
             for value in range(0, 0xFF, 0x10):
                 self.cpu.registers['v'][register] = value
                 self.cpu.operand = register << 8
+                self.cpu.operand = self.cpu.operand + (register << 4)
                 for index in range(1, 8):
                     shifted_val = value >> index
                     self.cpu.registers['v'][0xF] = 0
@@ -319,6 +320,7 @@ class TestChip8CPU(unittest.TestCase):
             for value in range(256):
                 self.cpu.registers['v'][register] = value
                 self.cpu.operand = register << 8
+                self.cpu.operand = self.cpu.operand + (register << 4)
                 for index in range(1, 8):
                     shifted_val = value << index
                     bit_seven = (shifted_val & 0x100) >> 9
@@ -530,7 +532,7 @@ class TestChip8CPU(unittest.TestCase):
         self.cpu.registers['v'][0] = 1
         self.cpu.registers['pc'] = 0
         result_table = [False] * 512
-        result_table[pygame.K_KP0 + 1] = True
+        result_table[pygame.K_4] = True
         with mock.patch("pygame.key.get_pressed", return_value=result_table) as key_mock:
             self.cpu.keyboard_routines()
             self.assertTrue(key_mock.asssert_called)
@@ -561,7 +563,7 @@ class TestChip8CPU(unittest.TestCase):
         self.cpu.registers['v'][0] = 1
         self.cpu.registers['pc'] = 0
         result_table = [False] * 512
-        result_table[pygame.K_KP0 + 1] = True
+        result_table[pygame.K_4] = True
         with mock.patch("pygame.key.get_pressed", return_value=result_table) as key_mock:
             self.cpu.keyboard_routines()
             self.assertTrue(key_mock.asssert_called)


### PR DESCRIPTION
This PR updates two of the operations for the CPU - shift left and shift right. According to documentation online, the shift commands take a target register, and leave the source register value unchanged. Unit tests updated to reflect this functionality. Key mappings changed to make the keyboard easier to use. 