### PR TITLE
Python 36 Upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 sudo: false
 python:
-  - 2.7
+  - 3.6
 env:
   - DISPLAY=:99.0
 addons:
@@ -31,6 +31,6 @@ services:
 virtalenv:
   system_site_packages: true
 script: 
-  - nosetests -v --with-coverage --cover-package=chip8
+  - coverage run -m nose
 after_success:
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 sudo: false
 python:

--- a/README.md
+++ b/README.md
@@ -66,23 +66,23 @@ and run the emulator in, without touching your master Python environment.
 
 ### Ubuntu Installation
 
-The installation under Ubuntu requires several different steps:
+The installation under Ubuntu 20.04 requires several different steps:
 
 1. Install SDL libraries. The SDL (Simple DirectMedia Layer) libraries are used by PyGame to draw 
 images on the screen. Several other dependencies are needed by SDL in order to install PyGame. 
 To install the required SDL libraries (plus dependencies) from the command-line:
 
     ```
-    sudo apt-get install libfreetype6-dev libsdl-dev libsdl-image1.2-dev \ 
-    libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl-sound1.2-dev \
-    libportmidi-dev python-dev
+    sudo apt install python3 python3-dev libsdl-dev libfreetype6-dev \
+    libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl-sound1.2-dev \
+    libportmidi-dev
     ```
 
 2. Install PIP. The `pip` package manager is used for managing Python packages. To install `pip` 
 from the command-line:
 
     ```
-    sudo apt-get install python-pip
+    sudo apt install python3-pip
     ```
 
 3. (*Optional*) Install virtual environment support for Python:
@@ -90,8 +90,8 @@ from the command-line:
     1. Install virtual environment support:
 
     ```
-    pip install virtualenv
-    pip install virtualenvwrapper
+    pip3 install virtualenv
+    pip3 install virtualenvwrapper
     ```
 
     2. First you must update your `.bashrc` file in the your home directory and add a few lines 
@@ -99,8 +99,10 @@ from the command-line:
 
     ```
     cat >> ~/.bashrc << EOF
+    export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
     export WORKON_HOME=$HOME/.virtualenvs
-    source /usr/local/bin/virtualenvwrapper.sh
+    export PATH=$PATH:$HOME/.local/bin
+    source $HOME/.local/bin/virtualenvwrapper.sh
     EOF
     ```
 
@@ -119,7 +121,7 @@ from the command-line:
 5. Clone (or download) the Chip 8 emulator project:
 
     ```
-    sudo apt-get install git
+    sudo apt install git
     git clone https://github.com/craigthomas/Chip8Python.git
     ```
 
@@ -134,7 +136,7 @@ from the command-line:
 
 1. Download and install [Python 3.6.8 for Windows](https://www.python.org/downloads/release/python-368/). 
 Make sure that `pip` and `Add python.exe to Path` options are checked when performing the installation. Later
-versions of Ptyhon 3 are also likely to work correctly with the emulator.
+versions of Python 3 are also likely to work correctly with the emulator.
 
 2. (*Optional*) Install virtual environment support for Python. Run the following commands from a command prompt:
 
@@ -171,17 +173,18 @@ in the directory where you cloned or downloaded the source files:
 
 ### Running a ROM
 
+Note that if you created a virtual environment as detailed above, 
+you will need to `workon` that environment before starting the emulator:
+
+    workon chip8
+    
 The command-line interface requires a single argument, which is the full
 path to a Chip 8 ROM. Run the following command in the directory where you 
 cloned or downloaded the source files:
 
     python yac8e.py /path/to/rom/filename
 
-This will start the emulator with the specified ROM. Note that if you created 
-a virtual environment as detailed above, you will need to `workon` that 
-environment before starting the emulator:
-
-    workon chip8
+This will start the emulator with the specified ROM. 
 
 ### Screen Scale
 
@@ -254,13 +257,17 @@ keys that impact the execution of the emulator.
 
 ## ROM Compatibility
 
-Here are the list of public domain ROMs and their current status with the emulator.
+Here are the list of public domain ROMs and their current status with the emulator, along 
+with keypresses based on the default keymap:
 
 | ROM Name  | Works Correctly    | Notes                                                                               |
 | :-------- | :----------------: | :---------------------------------------------------------------------------------- |
 | MAZE      | :heavy_check_mark: |                                                                                     |
-| MISSILE   | :heavy_check_mark: | `u` fires                                                                           |
-| PONG      | :heavy_check_mark: | `4` left player up, `7` left player down, `v` right player up, `b` right player down|
+| MISSILE   | :heavy_check_mark: | `U` fires                                                                           |
+| PONG      | :heavy_check_mark: | `4` left player up, `7` left player down, `V` right player up, `B` right player down|
+| TANK      | :heavy_check_mark: | `R` fires, `T` moves right, `7` moves left, `5` moves down, `U` moves up            |
+| TETRIS    | :heavy_check_mark: | `R` moves left, `T` moves right, `Y` moves down, `7` rotates                        |
+| UFO       | :heavy_check_mark: | `R` fires up, `T` fires right, `7` fires left                                       |
 
 
 ## Further Documentation

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## What is it?
 
-This project is a Chip 8 emulator written in Python 2.7. The original purpose
+This project is a Chip 8 emulator written in Python 3.6+. The original purpose
 of the project was to create a simple learning emulator that was well
 documented and coded in terms that were easy to understand. It was also an
 exercise to learn more about Python. The result is a simple command-line
@@ -54,7 +54,7 @@ This project makes use of an MIT style license. Please see the file called LICEN
 Copy the source files to a directory of your choice. In addition to
 the source, you will need the following required software packages:
 
-* [Python 2.7](http://www.python.org)
+* [Python 3.6.8 or better](http://www.python.org)
 * [pygame](http://www.pygame.org)
 
 I strongly recommend creating a virtual environment using the 
@@ -132,8 +132,9 @@ from the command-line:
 
 ### Windows Installation
 
-1. Download and install [Python 2.7.15 for Windows](https://www.python.org/downloads/release/python-2715/). 
-Make sure that `pip` and `Add python.exe to Path` options are checked when performing the installation.
+1. Download and install [Python 3.6.8 for Windows](https://www.python.org/downloads/release/python-368/). 
+Make sure that `pip` and `Add python.exe to Path` options are checked when performing the installation. Later
+versions of Ptyhon 3 are also likely to work correctly with the emulator.
 
 2. (*Optional*) Install virtual environment support for Python. Run the following commands from a command prompt:
 
@@ -174,7 +175,7 @@ The command-line interface requires a single argument, which is the full
 path to a Chip 8 ROM. Run the following command in the directory where you 
 cloned or downloaded the source files:
 
-    python chip8/yac8e.py /path/to/rom/filename
+    python yac8e.py /path/to/rom/filename
 
 This will start the emulator with the specified ROM. Note that if you created 
 a virtual environment as detailed above, you will need to `workon` that 
@@ -184,20 +185,20 @@ environment before starting the emulator:
 
 ### Screen Scale
 
-The `-s` switch will scale the size of the window (the original size at 1x
+The `--scale` switch will scale the size of the window (the original size at 1x
 scale is 64 x 32):
 
-    python chip8/yac8e.py /path/to/rom/filename -s 10
+    python yac8e.py /path/to/rom/filename --scale 10
 
 The command above will scale the window so that it is 10 times the normal
 size.
 
 ### Execution Delay
 
-You may also wish to experiment with the `-d` switch, which instructs
+You may also wish to experiment with the `--delay` switch, which instructs
 the emulator to add a delay to every operation that is executed. For example,
 
-    python chip8/yac8e.py /path/to/rom/filename -d 10
+    python yac8e.py /path/to/rom/filename --delay 10
 
 The command above will add a 10 ms delay to every opcode that is executed.
 This is useful for very fast computers (note that it is difficult to find
@@ -255,9 +256,11 @@ keys that impact the execution of the emulator.
 
 Here are the list of public domain ROMs and their current status with the emulator.
 
-| ROM Name          | Works Correctly    | Notes |
-| :---------------: | :----------------: | :---: |
-| MAZE              | :heavy_check_mark: |       |
+| ROM Name  | Works Correctly    | Notes                                                                               |
+| :-------: | :----------------: | :---------------------------------------------------------------------------------: |
+| MAZE      | :heavy_check_mark: |                                                                                     |
+| MISSILE   | :heavy_check_mark: | `u` fires                                                                           |
+| PONG      | :heavy_check_mark: | `4` left player up, `7` left player down, `v` right player up, `b` right player down|
 
 
 ## Further Documentation

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ keys that impact the execution of the emulator.
 Here are the list of public domain ROMs and their current status with the emulator.
 
 | ROM Name  | Works Correctly    | Notes                                                                               |
-| :-------: | :----------------: | :---------------------------------------------------------------------------------: |
+| :-------- | :----------------: | :---------------------------------------------------------------------------------- |
 | MAZE      | :heavy_check_mark: |                                                                                     |
 | MISSILE   | :heavy_check_mark: | `u` fires                                                                           |
 | PONG      | :heavy_check_mark: | `4` left player up, `7` left player down, `v` right player up, `b` right player down|

--- a/chip8/cpu.py
+++ b/chip8/cpu.py
@@ -11,7 +11,7 @@ import pygame
 from pygame import key
 from random import randint
 
-from config import (
+from chip8.config import (
     MAX_MEMORY, STACK_POINTER_START, KEY_MAPPINGS, PROGRAM_COUNTER_START
 )
 
@@ -667,14 +667,14 @@ class Chip8CPU(object):
         :param y_pos: the Y position of the sprite
         :param num_bytes: the number of bytes to draw
         """
-        for y_index in xrange(num_bytes):
+        for y_index in range(num_bytes):
 
             color_byte = bin(self.memory[self.registers['index'] + y_index])
             color_byte = color_byte[2:].zfill(8)
             y_coord = y_pos + y_index
             y_coord = y_coord % self.screen.get_height()
 
-            for x_index in xrange(8):
+            for x_index in range(8):
 
                 x_coord = x_pos + x_index
                 x_coord = x_coord % self.screen.get_width()
@@ -704,9 +704,9 @@ class Chip8CPU(object):
         :param y_pos: the Y position of the sprite
         :param num_bytes: the number of bytes to draw
         """
-        for y_index in xrange(num_bytes):
+        for y_index in range(num_bytes):
 
-            for x_byte in xrange(2):
+            for x_byte in range(2):
 
                 color_byte = bin(self.memory[self.registers['index'] + (y_index * 2) + x_byte])
                 color_byte = color_byte[2:].zfill(8)

--- a/chip8/emulator.py
+++ b/chip8/emulator.py
@@ -6,12 +6,11 @@ A simple Chip 8 emulator - see the README file for more information.
 """
 # I M P O R T S ###############################################################
 
-import argparse
 import pygame
 
-from config import FONT_FILE, DELAY_INTERVAL
-from cpu import Chip8CPU
-from screen import Chip8Screen
+from chip8.config import FONT_FILE, DELAY_INTERVAL
+from chip8.cpu import Chip8CPU
+from chip8.screen import Chip8Screen
 
 # C O N S T A N T S ###########################################################
 
@@ -19,28 +18,6 @@ from screen import Chip8Screen
 TIMER = pygame.USEREVENT + 1
 
 # F U N C T I O N S  ##########################################################
-
-
-def parse_arguments():
-    """
-    Parses the command-line arguments passed to the emulator.
-
-    :return: the parsed command-line arguments
-    """
-    parser = argparse.ArgumentParser(
-        description="Starts a simple Chip 8 "
-        "emulator. See README.md for more information, and LICENSE for "
-        "terms of use.")
-    parser.add_argument(
-        "rom", help="the ROM file to load on startup")
-    parser.add_argument(
-        "-s", help="the scale factor to apply to the display "
-        "(default is 5)", type=int, default=5, dest="scale")
-    parser.add_argument(
-        "-d", help="sets the CPU operation to take at least "
-        "the specified number of milliseconds to execute (default is 1)",
-        type=int, default=1, dest="op_delay")
-    return parser.parse_args()
 
 
 def main_loop(args):
@@ -70,11 +47,5 @@ def main_loop(args):
                 keys_pressed = pygame.key.get_pressed()
                 if keys_pressed[pygame.K_ESCAPE]:
                     cpu.running = False
-
-
-# M A I N #####################################################################
-
-if __name__ == "__main__":
-    main_loop(parse_arguments())
 
 # E N D   O F   F I L E #######################################################

--- a/chip8/screen.py
+++ b/chip8/screen.py
@@ -180,14 +180,14 @@ class Chip8Screen(object):
         
         :param num_lines: the number of lines to scroll down 
         """
-        for y_pos in xrange(self.height - num_lines, -1, -1):
-            for x_pos in xrange(self.width):
+        for y_pos in range(self.height - num_lines, -1, -1):
+            for x_pos in range(self.width):
                 pixel_color = self.get_pixel(x_pos, y_pos)
                 self.draw_pixel(x_pos, y_pos + num_lines, pixel_color)
 
         # Blank out the lines above the ones we scrolled
-        for y_pos in xrange(num_lines):
-            for x_pos in xrange(self.width):
+        for y_pos in range(num_lines):
+            for x_pos in range(self.width):
                 self.draw_pixel(x_pos, y_pos, 0)
 
         self.update()
@@ -196,14 +196,14 @@ class Chip8Screen(object):
         """
         Scroll the screen left 4 pixels.
         """
-        for y_pos in xrange(self.height):
-            for x_pos in xrange(4, self.width):
+        for y_pos in range(self.height):
+            for x_pos in range(4, self.width):
                 pixel_color = self.get_pixel(x_pos, y_pos)
                 self.draw_pixel(x_pos - 4, y_pos, pixel_color)
 
         # Blank out the lines to the right of the ones we just scrolled
-        for y_pos in xrange(self.height):
-            for x_pos in xrange(self.width - 4, self.width):
+        for y_pos in range(self.height):
+            for x_pos in range(self.width - 4, self.width):
                 self.draw_pixel(x_pos, y_pos, 0)
 
         self.update()
@@ -212,14 +212,14 @@ class Chip8Screen(object):
         """
         Scroll the screen right 4 pixels.
         """
-        for y_pos in xrange(self.height):
-            for x_pos in xrange(self.width - 4, -1, -1):
+        for y_pos in range(self.height):
+            for x_pos in range(self.width - 4, -1, -1):
                 pixel_color = self.get_pixel(x_pos, y_pos)
                 self.draw_pixel(x_pos + 4, y_pos, pixel_color)
 
         # Blank out the lines to the left of the ones we just scrolled
-        for y_pos in xrange(self.height):
-            for x_pos in xrange(4):
+        for y_pos in range(self.height):
+            for x_pos in range(4):
                 self.draw_pixel(x_pos, y_pos, 0)
 
         self.update()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pygame
-coveralls
 mock
+nose
+coverage

--- a/test/test_chip8cpu.py
+++ b/test/test_chip8cpu.py
@@ -580,13 +580,13 @@ class TestChip8CPU(unittest.TestCase):
     def test_execute_instruction_raises_exception_on_unknown_op_code(self):
         with self.assertRaises(UnknownOpCodeException) as context:
             self.cpu.execute_instruction(operand=0x8008)
-        self.assertEqual("Unknown op-code: 8008", context.exception.message)
+        self.assertEqual("Unknown op-code: 8008", str(context.exception))
 
     def test_execute_instruction_raises_exception_on_unknown_op_code_from_cpu(self):
         with self.assertRaises(UnknownOpCodeException) as context:
             self.cpu.operand = 0x8008
             self.cpu.execute_instruction(operand=0x8008)
-        self.assertEqual("Unknown op-code: 8008", context.exception.message)
+        self.assertEqual("Unknown op-code: 8008", str(context.exception))
 
     def test_execute_instruction_on_operand_in_memory(self):
         self.cpu.registers['pc'] = 0x200
@@ -596,7 +596,7 @@ class TestChip8CPU(unittest.TestCase):
         self.assertEqual(0x202, self.cpu.registers['pc'])
 
     def test_execute_logical_instruction_raises_exception_on_unknown_op_codes(self):
-        for x in xrange(8, 14):
+        for x in range(8, 14):
             self.cpu.operand = x
             with self.assertRaises(UnknownOpCodeException):
                 self.cpu.execute_logical_instruction()
@@ -610,7 +610,7 @@ class TestChip8CPU(unittest.TestCase):
         self.cpu.operand = 0x0
         with self.assertRaises(UnknownOpCodeException) as context:
             self.cpu.misc_routines()
-        self.assertEqual("Unknown op-code: 0", context.exception.message)
+        self.assertEqual("Unknown op-code: 0", str(context.exception))
 
     def test_scroll_down_called(self):
         self.cpu.operand = 0x00C4
@@ -753,7 +753,9 @@ class TestChip8CPU(unittest.TestCase):
         self.cpu.operand = 0xBA
         self.cpu.registers['index'] = 0xDEAD
         result = str(self.cpu)
-        self.assertEqual("PC: BEED  OP:   BA\nV0:  0\nV1:  1\nV2:  2\nV3:  3\nV4:  4\nV5:  5\nV6:  6\nV7:  7\nV8:  8\nV9:  9\nVA:  A\nVB:  B\nVC:  C\nVD:  D\nVE:  E\nVF:  F\nI: DEAD\n", result)
+        self.assertEqual(
+            "PC: BEED  OP:   BA\nV0:  0\nV1:  1\nV2:  2\nV3:  3\nV4:  4\nV5:  5\nV6:  6"
+            "\nV7:  7\nV8:  8\nV9:  9\nVA:  A\nVB:  B\nVC:  C\nVD:  D\nVE:  E\nVF:  F\nI: DEAD\n", result)
 
     def test_wait_for_keypress(self):
         EventMock = collections.namedtuple('EventMock', 'type')

--- a/yac8e.py
+++ b/yac8e.py
@@ -1,0 +1,47 @@
+"""
+Copyright (C) 2012-2019 Craig Thomas
+This project uses an MIT style license - see LICENSE for details.
+
+A simple Chip 8 emulator - see the README file for more information.
+"""
+# I M P O R T S ###############################################################
+
+import argparse
+import os
+
+# G L O B A L S ###############################################################
+
+os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
+
+# F U N C T I O N S  ##########################################################
+
+
+def parse_arguments():
+    """
+    Parses the command-line arguments passed to the emulator.
+
+    :return: the parsed command-line arguments
+    """
+    parser = argparse.ArgumentParser(
+        description="Starts a simple Chip 8 "
+        "emulator. See README.md for more information, and LICENSE for "
+        "terms of use.")
+    parser.add_argument(
+        "rom", help="the ROM file to load on startup")
+    parser.add_argument(
+        "--scale", help="the scale factor to apply to the display "
+        "(default is 5)", type=int, default=5, dest="scale")
+    parser.add_argument(
+        "--delay", help="sets the CPU operation to take at least "
+        "the specified number of milliseconds to execute (default is 1)",
+        type=int, default=1, dest="op_delay")
+    return parser.parse_args()
+
+
+# M A I N #####################################################################
+
+if __name__ == "__main__":
+    from chip8.emulator import main_loop
+    main_loop(parse_arguments())
+
+# E N D   O F   F I L E #######################################################


### PR DESCRIPTION
This PR updates the core project to use Python 3.6 as the interpreter (given that Python 2 has now been sunset). Any version of Python 3.6 or better should work with the source files. Python 2 specific language has been removed, and replaced with Python 3 specific language. README has been updated with new instructions on how to run the emulator with Python 3.