### PR TITLE
added pygame.init() / Program couldn't run before

### DIFF
--- a/chip8/emulator.py
+++ b/chip8/emulator.py
@@ -31,6 +31,7 @@ def main_loop(args):
     cpu = Chip8CPU(screen)
     cpu.load_rom(FONT_FILE, 0)
     cpu.load_rom(args.rom)
+    pygame.init()
     pygame.time.set_timer(TIMER, DELAY_INTERVAL)
 
     while cpu.running:


### PR DESCRIPTION
Thank you for your contribution! Before submitting this PR, please make sure:

- [X] The unit test suite runs without any errors or warnings 
    - If the unit test suite fails, and you believe the failure is due to the test suite, please let us know in your PR description
    - We recommend using `nose` to run the unit test suite with the command:
    ```
    nosetests -v --with-coverage --cover-package=chip8
    ```
- [X] You have followed [PEP 8 Style Guidelines](https://www.python.org/dev/peps/pep-0008/)
- [X] You have run [pylint](https://www.pylint.org/) on your code changes to check for errors or warnings
- [ ] You have added unit tests to cover the functionality you have added
    - We ask that at least 50% of the changeset you are submitting has been covered by tests

Error before:
```sh
Traceback (most recent call last):
  File "yac8e.py", line 45, in <module>
    main_loop(parse_arguments())
  File "/...Chip8Python/chip8/emulator.py", line 34, in main_loop
    pygame.time.set_timer(TIMER, DELAY_INTERVAL)
pygame.error: pygame is not initialized

```
