### PR TITLE
Default the interpreter to set memory size to 64K.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
       3. [Jump Quirks](#jump-quirks)
       4. [Clip Quirks](#clip-quirks)
       5. [Logic Quirks](#logic-quirks)
+   5. [Memory Size](#memory-size)
 5. [Customization](#customization)
    1. [Keys](#keys)
    2. [Debug Keys](#debug-keys)
@@ -292,6 +293,15 @@ sprites will not be allowed to wrap.
 The `--logic_quirks` controls whether the F register is cleared after logic operations
 such as AND, OR, and XOR. By default, F is left undefined following these operations.
 With the flag turned on, F will always be cleared.
+
+
+### Memory Size
+
+The original specification of the Chip8 language defined a 4K memory size for the
+interpreter. The addition of the XO Chip extensions require a 64K memory size
+for the interpreter. By default, the interpreter will start with a 64K memory size,
+but this behavior can be controlled with the `--mem_size` flag. Valid options are
+`64K` or `4K` for historical purposes.
 
 
 ## Customization

--- a/chip8/cpu.py
+++ b/chip8/cpu.py
@@ -6,8 +6,6 @@ A Chip 8 CPU - see the README file for more information.
 """
 # I M P O R T S ###############################################################
 
-import pygame
-
 from pygame import key
 from random import randint
 
@@ -69,7 +67,7 @@ class Chip8CPU:
             jump_quirks=False,
             clip_quirks=False,
             logic_quirks=False,
-            mem_size="4K"
+            mem_size="64K"
     ):
         """
         Initialize the Chip8 CPU. The only required parameter is a screen

--- a/test/test_chip8cpu.py
+++ b/test/test_chip8cpu.py
@@ -9,7 +9,6 @@ A simple Chip 8 emulator - see the README file for more information.
 import mock
 import pygame
 import unittest
-import collections
 
 from mock import patch, call
 
@@ -34,6 +33,9 @@ class TestChip8CPU(unittest.TestCase):
         self.screen = mock.MagicMock()
         self.cpu = Chip8CPU(self.screen)
         self.cpu_spy = mock.Mock(wraps=self.cpu)
+
+    def test_memory_size_default_64k(self):
+        self.assertEqual(65536, len(self.cpu.memory))
 
     def test_return_from_subroutine(self):
         for address in range(0x200, 0xFFFF, 0x10):

--- a/yac8e.py
+++ b/yac8e.py
@@ -57,8 +57,8 @@ def parse_arguments():
         action="store_true", dest="logic_quirks"
     )
     parser.add_argument(
-        "--mem_size", help="Maximum memory size (4K default)",
-        dest="mem_size", choices=["4K", "64K"], default="4K"
+        "--mem_size", help="Maximum memory size (64K default)",
+        dest="mem_size", choices=["4K", "64K"], default="64K"
     )
     parser.add_argument(
         "--trace", help="print registers and instructions to STDOUT",


### PR DESCRIPTION
This PR changes the emulator to use a 64K memory space by default instead of the 4K memory space as defined by the original Chip8 language specification. This memory size can be changed by using the `--mem_space` flag if desired. Unit test added to catch new condition. This PR closes #24 
