### PR TITLE
Add Store Subset of Registers

### DIFF
--- a/test/test_chip8cpu.py
+++ b/test/test_chip8cpu.py
@@ -914,6 +914,47 @@ class TestChip8CPU(unittest.TestCase):
         self.assertEqual(1, self.cpu.keypress_register)
         self.assertTrue(self.cpu.awaiting_keypress)
 
+    def test_store_subset_regs_one_two(self):
+        self.cpu.v[1] = 5
+        self.cpu.v[2] = 6
+        self.cpu.index = 0x5000
+        self.cpu.operand = 0xF122
+        self.cpu.store_subset_regs_in_memory()
+        self.assertEqual(5, self.cpu.memory[0x5000])
+        self.assertEqual(6, self.cpu.memory[0x5001])
+
+    def test_store_subset_regs_one_one(self):
+        self.cpu.v[1] = 5
+        self.cpu.v[2] = 6
+        self.cpu.index = 0x5000
+        self.cpu.operand = 0xF112
+        self.cpu.store_subset_regs_in_memory()
+        self.assertEqual(5, self.cpu.memory[0x5000])
+        self.assertEqual(0, self.cpu.memory[0x5001])
+
+    def test_store_subset_regs_three_one(self):
+        self.cpu.v[1] = 5
+        self.cpu.v[2] = 6
+        self.cpu.v[3] = 7
+        self.cpu.index = 0x5000
+        self.cpu.operand = 0xF312
+        self.cpu.store_subset_regs_in_memory()
+        self.assertEqual(7, self.cpu.memory[0x5000])
+        self.assertEqual(6, self.cpu.memory[0x5001])
+        self.assertEqual(5, self.cpu.memory[0x5002])
+
+    def test_store_subset_regs_integration(self):
+        self.cpu.v[1] = 5
+        self.cpu.v[2] = 6
+        self.cpu.v[3] = 7
+        self.cpu.index = 0x5000
+        self.cpu.memory[0x0200] = 0xF3
+        self.cpu.memory[0x0201] = 0x12
+        self.cpu.execute_instruction()
+        self.assertEqual(7, self.cpu.memory[0x5000])
+        self.assertEqual(6, self.cpu.memory[0x5001])
+        self.assertEqual(5, self.cpu.memory[0x5002])
+
 # M A I N #####################################################################
 
 


### PR DESCRIPTION
This PR adds the ability to store a subset of registers into memory starting from the index pointer. Note that the index register is not updated. Unit and integration tests added to cover new conditions. This PR closes #25 