### PR TITLE
Add Bitplane Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,8 +314,8 @@ Color values are specified by using HTML hex values such as `AABBCC` without the
 leading `#`. There are currently 4 color values that can be set:
 
 * `--color_0` specifies the background color. This defaults to `000000`.
-* `--color_1` specifies bitplane 1 color. This defaults to `666666`.
-* `--color_2` specifies bitplane 2 color. This defaults to `BBBBBB`.
+* `--color_1` specifies bitplane 1 color. This defaults to `FF33CC`.
+* `--color_2` specifies bitplane 2 color. This defaults to `33CCFF`.
 * `--color_3` specifies bitplane 1 and 2 overlap color. This defaults to `FFFFFF`.
 
 For Chip8 and SuperChip 8 programs, only the background color `color_0` (for pixels

--- a/test/test_chip8cpu.py
+++ b/test/test_chip8cpu.py
@@ -689,7 +689,7 @@ class TestChip8CPU(unittest.TestCase):
     def test_clear_screen(self):
         self.cpu.operand = 0xE0
         self.cpu.clear_return()
-        self.screen.clear_screen.assert_called_with()
+        self.screen.clear_screen.assert_called_with(1)
 
     def test_clear_return_from_subroutine(self):
         self.cpu.operand = 0xEE
@@ -811,10 +811,16 @@ class TestChip8CPU(unittest.TestCase):
             self.cpu.misc_routines()
         self.assertEqual("Unknown op-code: F0FF", str(context.exception))
 
+    def test_save_skip_routines_raises_exception_on_unknown_op_codes(self):
+        self.cpu.operand = 0x50FF
+        with self.assertRaises(UnknownOpCodeException) as context:
+            self.cpu.misc_routines()
+        self.assertEqual("Unknown op-code: 50FF", str(context.exception))
+
     def test_scroll_down_called(self):
         self.cpu.operand = 0x00C4
         self.cpu.clear_return()
-        self.screen.scroll_down.assert_called_with(4)
+        self.screen.scroll_down.assert_called_with(4, 1)
 
     def test_scroll_right_called(self):
         self.cpu.operand = 0x00FB
@@ -859,17 +865,17 @@ class TestChip8CPU(unittest.TestCase):
         screen_mock.width = 64
         self.cpu = Chip8CPU(screen_mock)
         self.cpu.memory[0] = 0xAA
-        self.cpu.draw_normal(0, 0, 1)
+        self.cpu.draw_normal(0, 0, 1, 1)
         with patch('chip8.screen.Chip8Screen.draw_pixel'):
             screen_mock.draw_pixel.assert_has_calls([
-                call(0, 0, 1),
-                call(1, 0, 0),
-                call(2, 0, 1),
-                call(3, 0, 0),
-                call(4, 0, 1),
-                call(5, 0, 0),
-                call(6, 0, 1),
-                call(7, 0, 0)
+                call(0, 0, 1, 1),
+                call(1, 0, 0, 1),
+                call(2, 0, 1, 1),
+                call(3, 0, 0, 1),
+                call(4, 0, 1, 1),
+                call(5, 0, 0, 1),
+                call(6, 0, 1, 1),
+                call(7, 0, 0, 1)
             ])
 
     def test_draw_sprite_turns_off_pixels(self):
@@ -880,26 +886,26 @@ class TestChip8CPU(unittest.TestCase):
         screen_mock.width = 64
         self.cpu = Chip8CPU(screen_mock)
         self.cpu.memory[0] = 0xAA
-        self.cpu.draw_normal(0, 0, 1)
-        self.cpu.draw_normal(0, 0, 1)
+        self.cpu.draw_normal(0, 0, 1, 1)
+        self.cpu.draw_normal(0, 0, 1, 1)
         with patch('chip8.screen.Chip8Screen.draw_pixel'):
             screen_mock.draw_pixel.assert_has_calls([
-                call(0, 0, 1),
-                call(1, 0, 0),
-                call(2, 0, 1),
-                call(3, 0, 0),
-                call(4, 0, 1),
-                call(5, 0, 0),
-                call(6, 0, 1),
-                call(7, 0, 0),
-                call(0, 0, 0),
-                call(1, 0, 0),
-                call(2, 0, 0),
-                call(3, 0, 0),
-                call(4, 0, 0),
-                call(5, 0, 0),
-                call(6, 0, 0),
-                call(7, 0, 0)
+                call(0, 0, 1, 1),
+                call(1, 0, 0, 1),
+                call(2, 0, 1, 1),
+                call(3, 0, 0, 1),
+                call(4, 0, 1, 1),
+                call(5, 0, 0, 1),
+                call(6, 0, 1, 1),
+                call(7, 0, 0, 1),
+                call(0, 0, 0, 1),
+                call(1, 0, 0, 1),
+                call(2, 0, 0, 1),
+                call(3, 0, 0, 1),
+                call(4, 0, 0, 1),
+                call(5, 0, 0, 1),
+                call(6, 0, 0, 1),
+                call(7, 0, 0, 1)
             ])
 
     def test_draw_sprite_does_not_turn_off_pixels(self):
@@ -910,27 +916,27 @@ class TestChip8CPU(unittest.TestCase):
         screen_mock.width = 64
         self.cpu = Chip8CPU(screen_mock)
         self.cpu.memory[0] = 0xAA
-        self.cpu.draw_normal(0, 0, 1)
+        self.cpu.draw_normal(0, 0, 1, 1)
         self.cpu.memory[0] = 0x55
-        self.cpu.draw_normal(0, 0, 1)
+        self.cpu.draw_normal(0, 0, 1, 1)
         with patch('chip8.screen.Chip8Screen.draw_pixel'):
             screen_mock.draw_pixel.assert_has_calls([
-                call(0, 0, 1),
-                call(1, 0, 0),
-                call(2, 0, 1),
-                call(3, 0, 0),
-                call(4, 0, 1),
-                call(5, 0, 0),
-                call(6, 0, 1),
-                call(7, 0, 0),
-                call(0, 0, 1),
-                call(1, 0, 1),
-                call(2, 0, 1),
-                call(3, 0, 1),
-                call(4, 0, 1),
-                call(5, 0, 1),
-                call(6, 0, 1),
-                call(7, 0, 1)
+                call(0, 0, 1, 1),
+                call(1, 0, 0, 1),
+                call(2, 0, 1, 1),
+                call(3, 0, 0, 1),
+                call(4, 0, 1, 1),
+                call(5, 0, 0, 1),
+                call(6, 0, 1, 1),
+                call(7, 0, 0, 1),
+                call(0, 0, 1, 1),
+                call(1, 0, 1, 1),
+                call(2, 0, 1, 1),
+                call(3, 0, 1, 1),
+                call(4, 0, 1, 1),
+                call(5, 0, 1, 1),
+                call(6, 0, 1, 1),
+                call(7, 0, 1, 1)
             ])
 
     def test_load_index_with_sprite(self):
@@ -975,7 +981,7 @@ class TestChip8CPU(unittest.TestCase):
         self.cpu.v[1] = 5
         self.cpu.v[2] = 6
         self.cpu.index = 0x5000
-        self.cpu.operand = 0xF122
+        self.cpu.operand = 0x5122
         self.cpu.store_subset_regs_in_memory()
         self.assertEqual(5, self.cpu.memory[0x5000])
         self.assertEqual(6, self.cpu.memory[0x5001])
@@ -984,7 +990,7 @@ class TestChip8CPU(unittest.TestCase):
         self.cpu.v[1] = 5
         self.cpu.v[2] = 6
         self.cpu.index = 0x5000
-        self.cpu.operand = 0xF112
+        self.cpu.operand = 0x5112
         self.cpu.store_subset_regs_in_memory()
         self.assertEqual(5, self.cpu.memory[0x5000])
         self.assertEqual(0, self.cpu.memory[0x5001])
@@ -994,7 +1000,7 @@ class TestChip8CPU(unittest.TestCase):
         self.cpu.v[2] = 6
         self.cpu.v[3] = 7
         self.cpu.index = 0x5000
-        self.cpu.operand = 0xF312
+        self.cpu.operand = 0x5312
         self.cpu.store_subset_regs_in_memory()
         self.assertEqual(7, self.cpu.memory[0x5000])
         self.assertEqual(6, self.cpu.memory[0x5001])
@@ -1005,7 +1011,7 @@ class TestChip8CPU(unittest.TestCase):
         self.cpu.v[2] = 6
         self.cpu.v[3] = 7
         self.cpu.index = 0x5000
-        self.cpu.memory[0x0200] = 0xF3
+        self.cpu.memory[0x0200] = 0x53
         self.cpu.memory[0x0201] = 0x12
         self.cpu.execute_instruction()
         self.assertEqual(7, self.cpu.memory[0x5000])
@@ -1016,7 +1022,7 @@ class TestChip8CPU(unittest.TestCase):
         self.cpu.v[1] = 5
         self.cpu.v[2] = 6
         self.cpu.index = 0x5000
-        self.cpu.operand = 0xF123
+        self.cpu.operand = 0x5123
         self.cpu.memory[0x5000] = 7
         self.cpu.memory[0x5001] = 8
         self.cpu.read_subset_regs_in_memory()
@@ -1027,7 +1033,7 @@ class TestChip8CPU(unittest.TestCase):
         self.cpu.v[1] = 5
         self.cpu.v[2] = 6
         self.cpu.index = 0x5000
-        self.cpu.operand = 0xF113
+        self.cpu.operand = 0x5113
         self.cpu.memory[0x5000] = 7
         self.cpu.memory[0x5001] = 8
         self.cpu.read_subset_regs_in_memory()
@@ -1039,7 +1045,7 @@ class TestChip8CPU(unittest.TestCase):
         self.cpu.v[2] = 6
         self.cpu.v[3] = 7
         self.cpu.index = 0x5000
-        self.cpu.operand = 0xF313
+        self.cpu.operand = 0x5313
         self.cpu.memory[0x5000] = 8
         self.cpu.memory[0x5001] = 9
         self.cpu.memory[0x5002] = 10
@@ -1053,7 +1059,7 @@ class TestChip8CPU(unittest.TestCase):
         self.cpu.v[2] = 6
         self.cpu.v[3] = 7
         self.cpu.index = 0x5000
-        self.cpu.memory[0x0200] = 0xF3
+        self.cpu.memory[0x0200] = 0x53
         self.cpu.memory[0x0201] = 0x13
         self.cpu.memory[0x5000] = 8
         self.cpu.memory[0x5001] = 9

--- a/yac8e.py
+++ b/yac8e.py
@@ -69,12 +69,12 @@ def parse_arguments():
         dest="color_0", default="000000"
     )
     parser.add_argument(
-        "--color_1", help="the hex color to use for bitplane 1 (default=666666)",
-        dest="color_1", default="666666"
+        "--color_1", help="the hex color to use for bitplane 1 (default=ff33cc)",
+        dest="color_1", default="ff33cc"
     )
     parser.add_argument(
-        "--color_2", help="the hex color to use for bitplane 2 (default=BBBBBB)",
-        dest="color_2", default="BBBBBB"
+        "--color_2", help="the hex color to use for bitplane 2 (default=33ccff)",
+        dest="color_2", default="33ccff"
     )
     parser.add_argument(
         "--color_3", help="the hex color to use for bitplane overlaps (default=FFFFFF)",


### PR DESCRIPTION
This PR introduces bitplanes to the emulator. A second drawing plane exists that can be targeted and blitted to separately from the original bitplane. In addition to this new functionality, a fix was added for storing and loading subsets of registers. The original issues reported that that functionality existed for `Fxy2` and `Fxy3`, which was incorrect. This has now been moved to `5xy2` and `5xy3` respectively. Unit and integration tests updated accordingly. This PR closes #28 