### PR TITLE
Fix right shift bit one bug

### DIFF
--- a/chip8/cpu.py
+++ b/chip8/cpu.py
@@ -699,7 +699,7 @@ class Chip8CPU:
             self.v[0xF] = bit_one
             self.last_op = f"SHR V{x:01X}"
         else:
-            bit_one = self.v[x] & 0x1
+            bit_one = self.v[y] & 0x1
             self.v[x] = self.v[y] >> 1
             self.v[0xF] = bit_one
             self.last_op = f"SHR V{x:01X}, V{y:01X}"

--- a/test/test_chip8cpu.py
+++ b/test/test_chip8cpu.py
@@ -399,6 +399,15 @@ class TestChip8CPU(unittest.TestCase):
                     self.assertEqual(self.cpu.v[x], shifted_val)
                     self.assertEqual(self.cpu.v[0xF], bit_zero)
 
+    def test_right_shift_reg_y_bug(self):
+        self.cpu.shift_quirks = False
+        self.cpu.operand = 0x0120
+        self.cpu.v[1] = 0
+        self.cpu.v[2] = 1
+        self.cpu.right_shift_reg()
+        self.assertEqual(0, self.cpu.v[1])
+        self.assertEqual(1, self.cpu.v[0xF])
+
     def test_subtract_reg_from_reg1(self):
         for x in range(0xF):
             for y in range(0xF):


### PR DESCRIPTION
This PR fixes a bug with right shifting where the incorrect register was being used to calculate what bit 0 should be. Regression test implemented to catch failing condition. This PR closes #48 