### PR TITLE
Limit instructions per second

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ An Octo compatible XO Chip, Super Chip, and Chip 8 emulator.
 4. [Running](#running)
    1. [Running a ROM](#running-a-rom)
    2. [Screen Scale](#screen-scale)
-   3. [Execution Delay](#execution-delay)
+   3. [Instructions Per Second](#instructions-per-second)
    4. [Quirks Modes](#quirks-modes)
       1. [Shift Quirks](#shift-quirks) 
       2. [Index Quirks](#index-quirks)

--- a/README.md
+++ b/README.md
@@ -207,18 +207,14 @@ scale is 64 x 32):
 The command above will scale the window so that it is 10 times the normal
 size.
 
-### Execution Delay
+### Instructions Per Second
 
-You may also wish to experiment with the `--delay` switch, which instructs
-the emulator to add a delay to every operation that is executed. For example,
+The `--ticks` switch will limit the number of instructions per second that the 
+emulator is allowed to run. By default, the value is set to 1,000. Minimum values 
+are 200. Use this switch to adjust the running time of ROMs that execute too quickly. 
+For simplicity, each instruction is assumed to take the same amount of time.
 
-    python yac8e.py /path/to/rom/filename --delay 10
-
-The command above will add a 10 ms delay to every opcode that is executed.
-This is useful for very fast computers (note that it is difficult to find
-information regarding opcode execution times, as such, I have not attempted
-any fancy timing mechanisms to ensure that instructions are executed in a
-set amount of time).
+    python yac8e.py /path/to/rom/filename --ticks 2000   
 
 ### Quirks Modes
 

--- a/chip8/emulator.py
+++ b/chip8/emulator.py
@@ -22,6 +22,7 @@ def main_loop(args):
     :param args: the parsed command-line arguments
     """
     delay_timer_event = 24
+    max_ticks = int(args.ticks / 60)
 
     screen = Chip8Screen(
         scale_factor=args.scale,
@@ -39,6 +40,7 @@ def main_loop(args):
         clip_quirks=args.clip_quirks,
         logic_quirks=args.logic_quirks,
         mem_size=args.mem_size,
+        max_ticks=max_ticks
     )
     cpu.load_rom(FONT_FILE, 0)
     cpu.load_rom(args.rom)
@@ -47,8 +49,6 @@ def main_loop(args):
     pygame.time.set_timer(delay_timer_event, 17)
 
     while cpu.running:
-        pygame.time.wait(args.op_delay)
-
         if not cpu.awaiting_keypress:
             cpu.execute_instruction()
 

--- a/yac8e.py
+++ b/yac8e.py
@@ -33,9 +33,8 @@ def parse_arguments():
         "--scale", help="the scale factor to apply to the display "
         "(default is 5)", type=int, default=5, dest="scale")
     parser.add_argument(
-        "--delay", help="sets the CPU operation to take at least "
-        "the specified number of milliseconds to execute (default is 1)",
-        type=int, default=1, dest="op_delay")
+        "--ticks", help="how many instructions per second are allowed",
+        type=int, default=1000, dest="ticks")
     parser.add_argument(
         "--shift_quirks", help="Enable shift quirks",
         action="store_true", dest="shift_quirks"


### PR DESCRIPTION
This PR introduces a new way to add CPU operation delay into the emulator. Instead of using a sleep delay, we now count operations per second, and limit the number that are allowed to execute. This speeds up the main loop since the overhead of starting a delay operation was quite high. The new instruction is introduced with the `--ticks` switch on the command line.